### PR TITLE
fix error in robust regression fit check

### DIFF
--- a/R/fra_class.R
+++ b/R/fra_class.R
@@ -454,8 +454,8 @@
   checkScalarType(data.name,"character")
   checkScalarType(sum.order,"integer")
   checkVectorType(series,"numeric")
-  if (!is.null(logfit) && !is.element(class(logfit),c("lm","lms","lts")))
-    stop("logfit must be a member of class \"lm\", \"lms\", or \"ltsreg\"")
+  if (!is.null(logfit) && !is.element(class(logfit),c("lm","lqs","lms","lts")))
+    stop("logfit must be a member of class \"lm\", \"lqs\", \"lms\", or \"ltsreg\"")
   if (!is.null(overlap) && ((overlap < 0) | (overlap >= 1)))
     stop("Overlap factor must be in the range [0,1)")
   if (!is.null(sdf) && !is(sdf,"SDF"))
@@ -1103,3 +1103,4 @@
 "asVector" <- function(x) if (inherits(x, "signalSeries")) x@data else as.vector(x)
 
 "eda.plot" <- function (x, ...) UseMethod("eda.plot")
+

--- a/man/fractalBlock.Rd
+++ b/man/fractalBlock.Rd
@@ -47,7 +47,7 @@ during the aggregation process.}
 
 \item{series}{a numeric vector containing the input series.}
 
-\item{logfit}{a linear regression model (such as that output by \code{lm}, \code{lmsreg}, or \code{ltsreg})
+\item{logfit}{a linear regression model (such as that output by \code{lm}, \code{lqs}, \code{lmsreg}, or \code{ltsreg})
 containing the regression model of the \code{log(scale)} versus \code{log(stat)} data.}
 \item{sdf}{spectral density function. Default: \code{NULL}.}
 }


### PR DESCRIPTION
Setting fit= to use either `lmsreg` or `ltsreg` from MASS was failing because both currently return value of class `lqs`.